### PR TITLE
Modified activity_share.xml

### DIFF
--- a/app/src/main/res/layout/activity_share.xml
+++ b/app/src/main/res/layout/activity_share.xml
@@ -39,6 +39,7 @@
                 android:layout_gravity="center"
                 android:autoLink="web"
                 android:text="@string/product_website"
+                android:textColorLink="#3700b3"
             />
             <TextView
                 android:layout_width="match_parent"


### PR DESCRIPTION
Hello,

I just discovered an issue with the color. The contrast between the foreground color and the background color of the link is insufficient, making it very difficult to read. Therefore, it should be changed to purple.

before：
![before](https://github.com/user-attachments/assets/bffe5df0-0de7-4c2c-995a-73c52ba397a4)

after：
![after](https://github.com/user-attachments/assets/b8616f95-e505-428f-899f-cfa79775d481)
